### PR TITLE
fix: added custom undo listeners when the buttons are redrawn by exca…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "y-excalidraw",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "type": "module",
   "description": "This binding binds a Y.Array to a Exacalidraw whiteboard.",
   "author": "Rahul Badenkal <rahulbadenkal@gmail.com>",

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -10,6 +10,17 @@ export const moveArrayItem = <T>(arr: T[], from: number, to: number, inPlace = t
   return arr
 };
 
+// https://stackoverflow.com/a/75988895
+export const debounce = (callback: any, wait: number) => {
+  let timeoutId = null;
+  return (...args) => {
+    clearTimeout(timeoutId);
+    timeoutId = setTimeout(() => {
+      callback(...args);
+    }, wait);
+  };
+}
+
 export const areElementsSame = (els1: readonly {id: string, version: number}[], els2: readonly {id: string, version: number}[]) => {
   if (els1.length !== els2.length) {
     return false

--- a/src/index.ts
+++ b/src/index.ts
@@ -229,13 +229,13 @@ export class ExcalidrawBinding {
     const _resizeListener = () => {
       if (!undoButton || !undoButton.isConnected) {
         undoButton?.removeEventListener('click', _undoBtnHandler)
-        undoButton = excalidrawDom.querySelector('[aria-label="Undo"]');  // Assuming new undoButton is added to dom by now?
+        undoButton = excalidrawDom.querySelector('[aria-label="Undo"]');  // Assuming new undoButton is added to dom by now
         undoButton.addEventListener('click', _undoBtnHandler);
       }
 
       if (!redoButton || !redoButton.isConnected) {
         redoButton?.removeEventListener('click', _undoBtnHandler)
-        redoButton = excalidrawDom.querySelector('[aria-label="Redo"]');  // Assuming new redoButton is added to dom by now?
+        redoButton = excalidrawDom.querySelector('[aria-label="Redo"]');  // Assuming new redoButton is added to dom by now
         redoButton.addEventListener('click', _redoBtnHandler);
       }
     }


### PR DESCRIPTION
Issue:
- When the screen sizes changes, excalidraw may redraw the dom related to all the menu items (including undo-redo buttons). In that case these new buttons don't have the custom listeners attached

Fix:
- Listening to resizing of the excalidraw conatiner and then reattaching the listeners if needed